### PR TITLE
issue_7: Add new option to dump Heroes, Teams and GameUnits

### DIFF
--- a/replay/__init__.py
+++ b/replay/__init__.py
@@ -432,8 +432,6 @@ class Replay():
                 self.team0.wastedDragonTime[general_dragon_count] = wasted_dragon_time_t0
                 self.team1.wastedDragonTime[general_dragon_count] = wasted_dragon_time_t1
 
-                print self.team0.wastedDragonTime[general_dragon_count], self.team1.wastedDragonTime[general_dragon_count], contested_time
-
                 #
                 if owner_team == 0:
                     dragon_count_0 += 1


### PR DESCRIPTION
I ran the following testing:
```
GM16727:hots-parser:cristiano (issue_7)$ python main.py -o /tmp/ -r replay/a.StormReplay 
Processing: replay/a.StormReplay
dumping heroes data into /tmp/2016-02-02_195112_heroes.json
GM16727:hots-parser:cristiano (issue_7)$ python main.py -o /tmp/ -t replay/a.StormReplay 
Processing: replay/a.StormReplay
dumping hero data into /tmp/2016-02-02_195123_teams.json
GM16727:hots-parser:cristiano (issue_7)$ python main.py -o /tmp/ -t replay/a.StormReplay 
Processing: replay/a.StormReplay
dumping teams data into /tmp/2016-02-02_195140_teams.json
GM16727:hots-parser:cristiano (issue_7)$ python main.py -o /tmp/ -u replay/a.StormReplay 
Processing: replay/a.StormReplay
dumping units data into /tmp/2016-02-02_195155_units.json
GM16727:hots-parser:cristiano (issue_7)$ python main.py -o /tmp/ -u -t replay/a.StormReplay 
Processing: replay/a.StormReplay
dumping teams data into /tmp/2016-02-02_195224_teams.json
dumping units data into /tmp/2016-02-02_195224_units.json
GM16727:hots-parser:cristiano (issue_7)$ python main.py -o /tmp/ -u -r replay/a.StormReplay 
Processing: replay/a.StormReplay
dumping heroes data into /tmp/2016-02-02_195233_heroes.json
dumping units data into /tmp/2016-02-02_195234_units.json
GM16727:hots-parser:cristiano (issue_7)$ python main.py -o /tmp/ -u -r -a replay/a.StormReplay 
Processing: replay/a.StormReplay
dumping heroes data into /tmp/2016-02-02_195243_heroes.json
dumping teams data into /tmp/2016-02-02_195243_teams.json
dumping units data into /tmp/2016-02-02_195243_units.json
```