### PR TITLE
Avoid out of index error by checking ownerList size first

### DIFF
--- a/replay/__init__.py
+++ b/replay/__init__.py
@@ -680,7 +680,7 @@ class Replay:
             self.unitsInGame[deadUnitTag].killerPlayerId = e['m_killerPlayerId']
             self.unitsInGame[deadUnitTag].positions[get_seconds_from_event_gameloop(e)] = [e['m_x'], e['m_y']]
 
-            if self.unitsInGame[deadUnitTag].is_plant_vehicle():
+            if self.unitsInGame[deadUnitTag].is_plant_vehicle() and len(self.unitsInGame[deadUnitTag].ownerList) > 0:
                 self.unitsInGame[deadUnitTag].ownerList[0][2] = self.unitsInGame[deadUnitTag].diedAt - \
                                                                 self.unitsInGame[deadUnitTag].ownerList[0][1]
 


### PR DESCRIPTION
I was getting the following error on a random Garden of Terror replay:

```
Traceback (most recent call last):
  File "main.py", line 277, in <module>
    replayData = processEvents(protocol, replay)
  File "/Users/andybaird/hots-parser/parser.py", line 21, in processEvents
    replay_data.process_replay()
  File "/Users/andybaird/hots-parser/replay/__init__.py", line 103, in process_replay
    self.process_event(event)
  File "/Users/andybaird/hots-parser/replay/__init__.py", line 118, in process_event
    getattr(self, event_name)(event)
  File "/Users/andybaird/hots-parser/replay/__init__.py", line 1251, in NNet_Replay_Tracker_SUnitDiedEvent
    self.get_unit_destruction(event)
  File "/Users/andybaird/hots-parser/replay/__init__.py", line 686, in get_unit_destruction
    self.unitsInGame[deadUnitTag].ownerList[0][1]
IndexError: list index out of range
```


This is a quick and dirty fix to prevent the error, but this probably doesn't fix the root problem. Feel free to reject this PR, but I thought I'd provide it just in case. 